### PR TITLE
修复首页「GDG 活动」 id 拼写错误

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
 				</div> <!-- end container -->
 			</section> <!-- end call to action -->
 
-			<section class="section-wrap bg-light" id="acitvity">
+			<section class="section-wrap bg-light" id="activity">
 				<div class="container">
 					<h2 class="text-center">GDG活动</h2>
 					<p class="subheading text-center"></p>


### PR DESCRIPTION
一点微小的改动…
现在首页点击导航中的「GDG 活动」没法响应。
